### PR TITLE
fix: drop the dead HUGO_VERSION pin from the Netlify config

### DIFF
--- a/data/netlify.toml
+++ b/data/netlify.toml
@@ -3,9 +3,12 @@
     publish = "public"
     command = "npm run build"
 
+# HUGO_VERSION is deliberately absent. The build invokes `hugo` from an npm script, which
+# resolves to node_modules/.bin/hugo provided by the hugo-extended dependency, so the
+# binary Netlify installs would be downloaded and then never used. The pin lives in
+# package.json, which is the single source of truth for the Hugo version.
 [build.environment]
     DART_SASS_VERSION = "1.98.0"
-    HUGO_VERSION = "0.158.0"
     HUGO_ENV = "production"
     HUGO_ENABLEGITINFO = "true"
     NODE_VERSION = "24.12.0"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,6 @@
     DART_SASS_VERSION = '1.98.0'
     HUGO_ENABLEGITINFO = 'true'
     HUGO_ENV = 'production'
-    HUGO_VERSION = '0.158.0'
     NODE_VERSION = '24.12.0'
     NPM_VERSION = '11.6.2'
 


### PR DESCRIPTION
## Problem

Netlify installed Hugo `0.158.0` on every build and then never used it.

The build invokes `hugo` from an npm script, which resolves to `node_modules/.bin/hugo` from the `hugo-extended` dependency — shadowing the binary Netlify installed. So the pin was adrift from the version that actually ran, and cost a pointless download each build. Anyone reading the Netlify config to find out which Hugo builds this project got the wrong answer.

This was found via a gethinode.com deploy log showing both halves at once: `Hugo version set to 0.153.1` followed by `hugo v0.164.0+extended`.

## Changes

Remove `HUGO_VERSION`, leaving `package.json` as the single pin. A comment records why the key is absent so it does not get restored later.

Where `netlify.toml` is generated from `data/netlify.toml` (do-not-modify header), the source file is edited and the generated output updated to match — a deletion-only change.

## Verification

The mechanism was verified end-to-end in gethinode.com: regenerating with no change reproduced the committed `netlify.toml` byte-for-byte, and regenerating after the removal produced exactly one deleted line, with no module-supplied `HUGO_VERSION` merging back in to replace it.

Each repo in this sweep was checked to confirm `hugo-extended` is a dependency and the Netlify build command routes through npm/pnpm scripts before the key was touched. Repos without an npm Hugo (`gethinode/customization-demo`, `gethinode/version-demo`) were deliberately excluded — their pin is load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)