### PR TITLE
ci: bound the Hugo cache key to an ISO week

### DIFF
--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -115,13 +115,27 @@ jobs:
       shell: pwsh
 
     # Cache Hugo cachedir and resourcedir (configured in config/ci/hugo.toml) for each OS.
-    # Rolling key restores the previous snapshot as a warm start, then saves a fresh one after build.
+    # The key restores the previous snapshot as a warm start, then saves a fresh one after build.
     # No additional content-based invalidation is needed; Hugo uses checksums itself.
+    #
+    # The suffix rotates weekly rather than per run. A run_id suffix saves a fresh entry every run and
+    # never reclaims the previous one, and a repository's Actions cache is a single ~10 GB LRU pool
+    # shared by every workflow in it — so those entries fill the pool and GitHub then evicts by last
+    # access, taking out the small caches other jobs depend on rather than the ones causing the
+    # pressure. An ISO-week suffix caps this prefix at roughly two live entries per OS per branch.
+    #
+    # %G/%V are the ISO year and week and must be paired — %Y/%V is wrong across a year boundary. The
+    # step needs an explicit bash shell because the Windows legs of the matrix default to pwsh.
+    - name: Compute the weekly cache epoch
+      id: cache-epoch
+      run: echo "week=$(date -u +%G-W%V)" >> "$GITHUB_OUTPUT"
+      shell: bash
+
     - name: Use Hugo cache
       uses: actions/cache@v6
       with:
         path: ${{ env.HUGO_CACHEDIR }}
-        key: ${{ runner.os }}-${{ env.CACHE_KEY }}-${{ github.run_id }}
+        key: ${{ runner.os }}-${{ env.CACHE_KEY }}-${{ steps.cache-epoch.outputs.week }}
         restore-keys: |
           ${{ runner.os }}-${{ env.CACHE_KEY }}-
 


### PR DESCRIPTION
## Summary

A cache key suffixed with `github.run_id` writes a brand-new entry every run and never reclaims the previous one. A repository's Actions cache is a single ~10 GB LRU pool shared by every workflow in it, so those entries fill the pool and GitHub evicts by last access — taking out the smallest, least recently read caches rather than whatever is causing the pressure.

This repo's Hugo cache was doing exactly that. Replacing the suffix with an ISO year-week caps each key prefix at roughly two live entries per branch.

## Notes

- `restore-keys` is unchanged, so the first run after this lands restores from the previous `run_id` entry and saves under the weekly key. No cold start during the transition.
- The suffix is not simply dropped: an exact-key hit makes `actions/cache` skip the save, so a fully static key would freeze the cache at its first-ever content forever.
- `%G`/`%V` are the ISO year and week and must be paired — `%Y`/`%V` emits a bogus `2027-W53` for 2027-01-01.
- No job or check names change, so branch protection is unaffected.
- `actionlint` reports no new findings against a pre-change baseline of this branch.

Stranded `run_id`-keyed entries are cleaned up separately once a run on `main` has saved under the new key.