### PR TITLE
fix(seo): let the site language decide og:locale and inLanguage

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -108,7 +108,7 @@
 [schema]
     type = "Organization"
     name = "Hinode"
-    locale = "en-US"
+    # locale = "en-US" # defaults to the locale of the current site language
     # twitter = "https://twitter.com/gethinode"
     # linkedIn = ""
     github = "https://github.com/gethinode/hinode"
@@ -129,7 +129,7 @@
 
 [opengraph]
     images = ["logo.png"]
-    locale = "en_US"
+    # locale = "en_US" # defaults to the locale of the current site language
 
 [links]
     hinode = "https://gethinode.com"


### PR DESCRIPTION
Companion to gethinode/hinode#2143, which fixes `og:locale` and the JSON-LD `inLanguage` reporting one site-wide value for every language. This is the repo through which that bug reaches real sites.

## Why this matters here

`config/_default/params.toml` ships hardcoded values:

```toml
[schema]
    locale = "en-US"
[opengraph]
    locale = "en_US"
```

Every site scaffolded from this template inherits them. Add a second language and each of its pages reports the locale of the first — a Dutch page serving `<html lang="nl">` next to `<meta property="og:locale" content="en_US">`. The markup is valid and the build is silent; only the two tags disagree, which is why it survives unnoticed. Found on a bilingual production site that had carried `en_US` on its Dutch tree since launch.

Project configuration wins over the theme by design, so **hinode#2143 alone does not reach any site scaffolded from here** — these two lines would keep shadowing the derivation. That is what this PR removes.

## Change

Both are commented out rather than deleted, so they stay discoverable as the escape hatch when a guess is wrong.

## Verification

Built with the currently pinned hinode v3.20.0, i.e. *before* the fix is released:

| | before | after |
|---|---|---|
| `og:locale` | `en_US` | `en_US` |
| `inLanguage` | `en-US` | `en-US` |

Unchanged, because the theme's own default supplies the same value today, and once #2143 releases this site is English with `languageCode = "en-us"`, which the new derivation resolves back to `en_US`. So there is no ordering constraint — this can merge before or after that release, and the scaffold's own output never moves. The change only starts to matter when a user adds a second language, which is precisely the case that used to fail silently.

`npm test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)